### PR TITLE
Fix deprecation warning on environment variable

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,7 @@
 - name: run virt-install script
   command: "bash {{ kickstart_tempdir }}/{{ inventory_hostname }}-install.sh"
   sudo: yes
-  environment: env_virt_install
+  environment: "{{ env_virt_install }}"
   args:
     creates: "/etc/libvirt/qemu/{{ inventory_hostname }}.xml"
   delegate_to: "{{ hyper }}"


### PR DESCRIPTION
Ansible will give a deprecation warning and fail if you don't add
parentheses around "env_virt_install".
