### PR TITLE
Make configuring a Puppet master optional

### DIFF
--- a/templates/kickstart.cfg
+++ b/templates/kickstart.cfg
@@ -83,7 +83,9 @@ echo "exclude=kernel*openstack*" >> /etc/yum.conf
 /usr/bin/yum clean all
 /usr/bin/yum update -y --skip-broken
 echo "{{ internal_ip }} {{ fqdn }}" >> /etc/hosts
+{% if puppetmaster_ip is defined %}
 echo "{{ puppetmaster_ip }}  puppetmaster puppet {{ puppetmaster_fqdn }}" >> /etc/hosts
+{% endif %}
 
 {% if root_keys is defined %}
 {% for root_key in root_keys %} 


### PR DESCRIPTION
It should not be mandatory to set a Puppet master IP if the VM you are
provisioning is not going to be managed by Puppet. This was the case for
one /etc/hosts entry added in the Kickstart template. Only add the line
for the Puppet master if the puppetmaster_ip variable is defined.
