### PR TITLE
Set virt_install_cpu_model based on distro

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,18 @@
   group_by: key=os_{{ ansible_distribution }}_{{ ansible_distribution_major_version }}
   delegate_to: "{{ hyper }}"
 
+- name: set variables specific to CentOS 6
+  set_fact:
+    virt_install_cpu_model: "host"
+  when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "6"
+  delegate_to: "{{ hyper }}"
+
+- name: set variables specific to CentOS 7
+  set_fact:
+    virt_install_cpu_model: "host-model"
+  when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "7"
+  delegate_to: "{{ hyper }}"
+
 - name: copy over kickstart file
   template: src="kickstart.cfg" dest="{{ kickstart_tempdir }}/{{ inventory_hostname }}.ks"
   sudo: yes


### PR DESCRIPTION
CentOS 6 and 7 versions of virt-install use different values for setting
the same CPU model as the host on the VM. Set these based on distro in
this role. Since virt_install_cpu_model must be set anyway, this change
means that the caller doesn't necessary need to set it.
