### PR TITLE
Allow configurable delegation of wait_for task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,7 +39,7 @@
 
 - name: wait for VM to become available before continuing
   wait_for: port=22 host="{{ inventory_hostname }}" timeout=300
-  delegate_to: "{{ hyper }}"
+  delegate_to: "{{ bastion_host | default(hyper) }}"
 
 - name: Remove kickstart file
   sudo: yes


### PR DESCRIPTION
Previously we always used the hypervisor of a VM as a jump host for that
VM to ensure SSH connectivity. In some cases we don't want to go through
the hypervisor but a different host instead. Create a new variable
called bastion_host for this, but use the "hyper" host as a default.
