### PR TITLE
Make installation of some packages optional

### DIFF
--- a/templates/kickstart.cfg
+++ b/templates/kickstart.cfg
@@ -54,18 +54,19 @@ part swap --asprimary --size=1024 --ondrive=vda
 
 %packages --nobase
 @core
-@server-policy
 {% if repos is defined %}
 {% for repo in repos %}
 {{ repo.pkgname }}
 {% endfor %}
 {% endif %}
-vim*
-man
+{% if puppetmaster_ip is defined %}
 puppet
 facter
 hiera
 erlang
+{% endif %}
+vim*
+man
 mlocate
 nc
 strace


### PR DESCRIPTION
Puppet doesn't need to be installed everywhere and erlang doesn't
either. Do not install these if the puppetmaster_ip variable is not set.
Also remove the @server-policy yum group as this seems to have no
packages in it in CentOS 7 and can cause installation issues with
certain mirrors.
