### PR TITLE
Allow configuring the wait address for port 22

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,7 +38,7 @@
   delegate_to: "{{ hyper }}"
 
 - name: wait for VM to become available before continuing
-  wait_for: port=22 host="{{ inventory_hostname }}" timeout=300
+  wait_for: port=22 host="{{ provisioning_wait_for_addr | default(inventory_hostname) }}" timeout=300
   delegate_to: "{{ bastion_host | default(hyper) }}"
 
 - name: Remove kickstart file


### PR DESCRIPTION
Sometimes it's inconvenient to wait for port 22 on the inventory
hostname. We might want to tell Ansible to just wait until port 22 is
reachable on some address from some other address. This can be useful
when dealing with machines that only have IPs in private nets.
