### PR TITLE
Rename location to install_url for clarity

### DIFF
--- a/templates/kickstart.cfg
+++ b/templates/kickstart.cfg
@@ -5,7 +5,7 @@ cmdline
 install
 reboot
 firstboot --disable
-url --url={{ location }}
+url --url={{ install_url }}
 
 # localization
 lang en_GB

--- a/templates/virt-install.sh
+++ b/templates/virt-install.sh
@@ -19,7 +19,7 @@ virt-install \
   --network bridge={{ bridge }},model=virtio \
 {% endfor %}
   --connect=qemu:///system \
-  --location={{ location }} \
+  --location={{ install_url }} \
   --graphics=vnc,keymap="fi" \
   --noautoconsole \
   --wait=20 \


### PR DESCRIPTION
When using this role, the name "location" for the install URL variable
is not very descriptive and easily becomes confusing. Rename the
variable to install_url instead.
