### PR TITLE
Add console definition to grub parameters

### DIFF
--- a/templates/virt-install.sh
+++ b/templates/virt-install.sh
@@ -25,5 +25,5 @@ virt-install \
   --autostart \
   --wait=20 \
   --initrd-inject={{ kickstart_tempdir }}/{{ inventory_hostname }}.ks \
-  --extra-args="ks=file:/{{ inventory_hostname }}.ks nomodeset"
+  --extra-args="ks=file:/{{ inventory_hostname }}.ks nomodeset console=ttyS0"
 fi


### PR DESCRIPTION
Tested with a CentOS7 guest. Seems to survive a reboot.
