### PR TITLE
proxy, vnc and logging

### DIFF
--- a/templates/kickstart.cfg
+++ b/templates/kickstart.cfg
@@ -5,7 +5,19 @@ cmdline
 install
 reboot
 firstboot --disable
-url --url={{ install_url }}
+
+{% if yum_proxy is defined %}
+url --url="{{ install_url }}" --proxy={{ yum_proxy }}
+{% else %}
+url --url="{{ install_url }}"
+{% endif %}
+
+# VNC
+{% if vnc_password is defined and (vnc_password|length >= 6 and vnc_password|length <= 8) %}
+vnc --password={{ vnc_password }}
+{% else %}
+vnc
+{% endif %}
 
 # localization
 lang en_GB
@@ -32,6 +44,11 @@ firewall --enabled --service=ssh
 {% for firewall_rule in firewall_rules %}
 {{ firewall_rule }}
 {% endfor %}
+{% endif %}
+
+{% if central_log_host is defined %}
+# Logging
+logging --host={{ central_log_host|replace("@","") }}
 {% endif %}
 
 # authentication


### PR DESCRIPTION
- some of the changes we've done to this file in
  https://github.com/CSC-IT-Center-for-Science/ansible-role-pxe_config/blob/master/templates/kickstart.cfg
- the @ in central_log_host is because https://github.com/CSC-IT-Center-for-Science/ansible-role-rsyslog/blob/master/defaults/main.yml#L4 
