### PR TITLE
Add central logging host to kickstart template

### DIFF
--- a/templates/kickstart.cfg
+++ b/templates/kickstart.cfg
@@ -34,6 +34,11 @@ firewall --enabled --service=ssh
 {% endfor %}
 {% endif %}
 
+{% if central_log_host is defined %}
+# Logging
+logging --host={{ central_log_host|replace("@","") }}
+{% endif %}
+
 # authentication
 rootpw {{ root_password }}
 authconfig --useshadow --passalgo=sha512 --kickstart


### PR DESCRIPTION
Define logging option in kickstart if central_log_host is defined.
