### PR TITLE
Configurable install timeout

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,6 @@
 ---
+# What packages to exclude in yum.conf at install time
 yum_exclude: ""
+
+# Time to wait for install to finish (in minutes)
+install_timeout: "30"

--- a/templates/virt-install.sh
+++ b/templates/virt-install.sh
@@ -23,7 +23,7 @@ virt-install \
   --graphics=vnc,keymap="fi" \
   --noautoconsole \
   --autostart \
-  --wait=20 \
+  --wait={{ install_timeout }} \
   --initrd-inject={{ kickstart_tempdir }}/{{ inventory_hostname }}.ks \
   --extra-args="ks=file:/{{ inventory_hostname }}.ks nomodeset console=ttyS0"
 fi


### PR DESCRIPTION
Previously the install timeout was always set to 20 minutes. Some
installations may take longer than this or it may be abnormal for an
installation to take that long. Thus make the timeout configurable on a
case-by-case basis using a new "install_timeout" variable.

Set a default of 30 minutes.
