### PR TITLE
Option for extra packages and no erlang by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,6 @@ yum_exclude: ""
 
 # Time to wait for install to finish (in minutes)
 install_timeout: "30"
+
+# Any additional packages to install during provisioning (as a list)
+extra_packages: []

--- a/templates/kickstart.cfg
+++ b/templates/kickstart.cfg
@@ -73,7 +73,11 @@ part swap --asprimary --size=1024 --ondrive=vda
 puppet
 facter
 hiera
-erlang
+{% endif %}
+{% if extra_packages is defined %}
+{% for pkg in extra_packages %}
+{{ pkg }}
+{% endfor %}
 {% endif %}
 vim*
 man


### PR DESCRIPTION
Add an option that allows installation of additional packages on a host
by host basis depending on the value of a new extra_packages variable.
Also remove installation of erlang by default. It is not needed on all
provisioned VMs. If erlang is needed, it can be installed using the new
extra_packages variable.
