### PR TITLE
Multiple network support for image based provision

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -127,12 +127,19 @@ timezone: Europe/Helsinki
 # List of admin users to add to new VM
 adminusers: []
 
-# DNS servers
-resolv_nameservers:
-  - 8.8.4.4
-  - 8.8.8.8
+# For cloud init networks, configure them in the same order the bridges
+# were added to the VM. gateway and nameservers are optional parameters
+#cloud_init_networks:
+#  - interface: eth0
+#    address: ip_for_eth0
+#    netmask: 255.255.255.0
+#  - interface: eth1
+#    address: ip_for_eth1
+#    netmask: 255.255.255.0
+#    gateway: gateway_ip
+#    nameservers: [ ns1_ip, ns2_ip ]
 
-#
+
 # If you want to add all your users, use an `adminusers` dictionary as required
 # for ansible-role-users:
 #   https://github.com/CSC-IT-Center-for-Science/ansible-role-users

--- a/tasks/image-guest.yml
+++ b/tasks/image-guest.yml
@@ -67,7 +67,7 @@
       group: qemu
     become: yes
 
-  - name: Copy guestfish script to fix CentOS 7 image to disable DHCP on eth0
+  - name: Copy guestfish script to fix CentOS 7 image networking
     template:
       src: modify-centos-image.guestfish.j2
       dest: "{{ runtime_tempdir }}/modify-centos-image.guestfish"
@@ -79,7 +79,7 @@
       - "'centos' in image_name.lower()"
       - "'7' in image_name"
 
-  - name: Fix CentOS 7 image to disable DHCP on eth0
+  - name: Fix CentOS 7 image to networking
     command: "/usr/bin/guestfish --rw -a {{ image_path}}/{{ fqdn }}.qcow2 -f {{ runtime_tempdir }}/modify-centos-image.guestfish"
     environment:
       LIBGUESTFS_BACKEND: direct # Fix first run on clean host with no VMs

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,14 @@
     that: hyper is defined
     msg: "hyper must be set to a hypervisor host where you want VMs to run"
 
+- name: Check network configuration for image-based deployments
+  assert:
+    that: cloud_init_networks is defined
+    msg: "Please configure your networks using cloud_init_networks. See defaults/main.yml"
+  when:
+    - guest_type is defined
+    - guest_type == 'image'
+
 # Most of this code will run on the hypervisor as defined by the hyper varible
 # We use a block to reduce repeating the 'delegate_to' for every task
 - block:

--- a/templates/meta-data.j2
+++ b/templates/meta-data.j2
@@ -4,11 +4,15 @@ instance-id: {{ inventory_hostname }}
 local-hostname: {{ inventory_hostname }}
 # The following block looks very debian-like but it works also in CentOS.
 network-interfaces: |
-  auto {{ eth_interface | default('eth0') }}
-  iface {{ eth_interface | default('eth0') }} inet static
-  address {{ internal_ip }}
-  netmask {{ netmask | default('255.255.255.0') }}
-{% if default_gateway is defined %}
-  gateway {{ default_gateway }}
+{% for item in cloud_init_networks %}
+  auto {{ item.interface }}
+  iface {{ item.interface }} inet static
+  address {{ item.address }}
+  netmask {{ item.netmask }}
+{% if item.gateway is defined %}
+  gateway {{ item.gateway }}
 {% endif %}
-  dns-nameservers {% for server in resolv_nameservers %}{{ server }} {% endfor %}
+{% if item.nameservers is defined %}
+  dns-nameservers {% for server in item.nameservers %}{{ server }} {% endfor %}
+{% endif %}
+{% endfor %}

--- a/templates/modify-centos-image.guestfish.j2
+++ b/templates/modify-centos-image.guestfish.j2
@@ -1,3 +1,4 @@
 run
 mount /dev/sda1 /
 rm /etc/sysconfig/network-scripts/ifcfg-eth0 
+rm /etc/resolv.conf


### PR DESCRIPTION
Added support for multiple networks for image-based provisioing. Since
this changed the expected configuration data, the defaults.yml was
documented. An assertion was also added to make sure this change doesn't
silently break deployments with older data.

Added a fix to remove resolv.conf for centos, it had a 10.0.2.3 dns
server there by default which did not get overwritten.