### PR TITLE
virt-viewer now works on kickstart

### DIFF
--- a/templates/kickstart.cfg
+++ b/templates/kickstart.cfg
@@ -50,7 +50,7 @@ authconfig --useshadow --passalgo=sha512 --kickstart
 selinux --disabled
 
 # disks
-bootloader --location=mbr --append="selinux=0 nomodeset"
+bootloader --location=mbr --append="selinux=0"
 zerombr
 clearpart --all --initlabel
 {% if kickstart_partitions is defined %}
@@ -66,7 +66,9 @@ part swap --asprimary --size=1024 --ondrive=vda
 @core
 {% if repos is defined %}
 {% for repo in repos %}
+{% if repo.pkgname is defined %}
 {{ repo.pkgname }}
+{% endif %}
 {% endfor %}
 {% endif %}
 {% if puppetmaster_ip is defined %}

--- a/templates/virt-install-script.sh.j2
+++ b/templates/virt-install-script.sh.j2
@@ -22,7 +22,7 @@ virt-install \
   --wait={{ install_timeout }} \
   --location={{ install_url }} \
   --initrd-inject={{ runtime_tempdir }}/{{ inventory_hostname }}.ks \
-  --extra-args="ks=file:/{{ inventory_hostname }}.ks nomodeset console=ttyS0"
+  --extra-args="ks=file:/{{ inventory_hostname }}.ks"
 {% else %}
   --events on_poweroff=preserve \
   --disk path={{ image_path}}/{{ fqdn }}.iso,device=cdrom,perms=ro \


### PR DESCRIPTION
Took away the nomodeset and console kernel parameters which hid the
install output before. This is a tradeoff, since virt-manager and
virt-viewer will work nicely, but virt-console won't.

Made it possible to have repos without a repo package to install (CentOS
Updates eg.).