### PR TITLE
Exclude - (hyphen) from password

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -85,9 +85,9 @@ env_virt_install: {}
 #networks:
 #  - "network --onboot=on --device=eth0 --bootproto=static --ip=VM_IP --netmask=VM_NETMASK --gateway=VM_GATEWAY --nameserver=NAMESERVER --hostname=VM_HOSTNAME"
 
-# Root password in kickstart format, only including letters, numbers and , and .
+# Root password in kickstart format, only including letters, numbers and . and _ and ,
 # Don't want password to start with "-" because kickstart/anaconda dislike that.
-#root_password: "{{ lookup('password', 'credentials/'+ inventory_hostname  +'_rootpw length=15 chars=ascii_letters,digits,hexdigits,.,,') }}"
+#root_password: "{{ lookup('password', 'credentials/'+ inventory_hostname  +'_rootpw length=15 chars=ascii_letters,digits,hexdigits,.,_,,') }}"
 
 # If you want to define a specific CPU model
 #virt_install_cpu_model:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -87,7 +87,7 @@ env_virt_install: {}
 
 # Root password in kickstart format, only including letters, numbers and . and _ and ,
 # Don't want password to start with "-" because kickstart/anaconda dislike that.
-#root_password: "{{ lookup('password', 'credentials/'+ inventory_hostname  +'_rootpw length=15 chars=ascii_letters,digits,hexdigits,.,_,,') }}"
+#root_password: "{{ lookup('password', 'credentials/'+ inventory_hostname  +'_rootpw length=15 chars=ascii_letters,digits,.,_,,') }}"
 
 # If you want to define a specific CPU model
 #virt_install_cpu_model:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -85,8 +85,9 @@ env_virt_install: {}
 #networks:
 #  - "network --onboot=on --device=eth0 --bootproto=static --ip=VM_IP --netmask=VM_NETMASK --gateway=VM_GATEWAY --nameserver=NAMESERVER --hostname=VM_HOSTNAME"
 
-# Root password in kickstart format
-#root_password: "{{ lookup('password', 'credentials/'+ inventory_hostname  +'_rootpw length=15') }}"
+# Root password in kickstart format, only including letters, numbers and , and .
+# Don't want password to start with "-" because kickstart/anaconda dislike that.
+#root_password: "{{ lookup('password', 'credentials/'+ inventory_hostname  +'_rootpw length=15 chars=ascii_letters,digits,hexdigits,.,,') }}"
 
 # If you want to define a specific CPU model
 #virt_install_cpu_model:

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -42,7 +42,7 @@
        - bridges: [ "br-example" ]
        - fqdn: "localhost"
        - install_url: "http://www.nic.funet.fi/pub/Linux/INSTALL/Centos/7/os/x86_64/"
-       - root_password: "changemeorperish"
+       - root_password: "{{ lookup('password', 'credentials/'+ inventory_hostname  +'_rootpw length=15 chars=ascii_letters,digits,hexdigits,.,,') }}"
 
    roles:
        - ansible-role-provision-vm

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -42,7 +42,7 @@
        - bridges: [ "br-example" ]
        - fqdn: "localhost"
        - install_url: "http://www.nic.funet.fi/pub/Linux/INSTALL/Centos/7/os/x86_64/"
-       - root_password: "{{ lookup('password', 'credentials/'+ inventory_hostname  +'_rootpw length=15 chars=ascii_letters,digits,hexdigits,.,,') }}"
+       - root_password: "{{ lookup('password', 'credentials/'+ inventory_hostname  +'_rootpw length=15 chars=ascii_letters,digits,hexdigits,.,_,,') }}"
 
    roles:
        - ansible-role-provision-vm


### PR DESCRIPTION
It's problematic if it's the first character in the password.

If root_password ends up being: "-S123123ABCabc" then anaconda will fail with

"-S" no such option.

If it starts with an underscore that's no problem.