### PR TITLE
Allow defining custom parameters to virt-install

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ guest_type: image          # Defaults to "kickstart"
 #vcpus: 1
 #ram: 1024
 
+# Numa tuning and ship console via syslog with virt-install:
+#provision_virt_install_extra_settings:
+# - "--numatune 1"
+# - "--serial udp,host=10.0.0.1:514"
+
 # Extra disks
 #disks:
 #  - path: "{{ libvirt_root }}/{{ fqdn }}.raw"
@@ -45,7 +50,7 @@ guest_type: image          # Defaults to "kickstart"
 
 # If you want to add all your users, use an `adminusers` dictionary as required
 # for ansible-role-users:
-#   https://github.com/CSC-IT-Center-for-Science/ansible-role-users
+#   https://github.com/CSCfi/ansible-role-users
 #
 # You can also add a custom user to your guests for bootstrapping
 #bootstrap_user: bootstrap
@@ -61,5 +66,5 @@ default_gateway: 1.2.3.4
 Optional (and only for Kickstart):
 ```
 install_url: "http://www.nic.funet.fi/pub/Linux/INSTALL/Centos/7/os/x86_64/"
-root_password: "{{ lookup('password', 'credentials/'+ inventory_hostname  +'_rootpw length=15') }}"
+root_password: "{{ lookup('password', 'credentials/'+ inventory_hostname  +'_rootpw length=15 chars=ascii_letters,digits,.,_,,') }}"
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -89,8 +89,9 @@ env_virt_install: {}
 # Don't want password to start with "-" because kickstart/anaconda dislike that.
 #root_password: "{{ lookup('password', 'credentials/'+ inventory_hostname  +'_rootpw length=15 chars=ascii_letters,digits,.,_,,') }}"
 
-# If you want to define a specific CPU model
-#virt_install_cpu_model:
+# If you want extra parameters in virt-install you may use this as an example:
+#provision_virt_install_extra_settings:
+# - "--numatune 1"
 
 # Specify an os-variant if you want
 os_variant: "rhel6"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,9 @@ install_timeout: "30"
 # Temp directory for storing provisioning related files
 provision_tempdir: "/tmp"
 
+# Cleanup runtime dir by default
+provision_cleanup_runtimedir: True
+
 # Where libvirt stores images and vms
 libvirt_root: "/var/lib/libvirt"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -142,5 +142,5 @@
     state: absent
   become: yes
   delegate_to: "{{ hyper }}"
-  when: guest_exists is failed
+  when: guest_exists is failed and provision_cleanup_runtimedir
 ...

--- a/templates/virt-install-script.sh.j2
+++ b/templates/virt-install-script.sh.j2
@@ -13,7 +13,7 @@ virt-install \
   --noautoconsole \
 {% if provision_virt_install_extra_settings is defined %}
 {% for param in provision_virt_install_extra_settings %}
-{{ param }} \
+  {{ param }} \
 {% endfor %}
 {% endif %}
 {% if guest_type is not defined or guest_type != "image" %}

--- a/templates/virt-install-script.sh.j2
+++ b/templates/virt-install-script.sh.j2
@@ -12,9 +12,9 @@ virt-install \
   --autostart \
   --noautoconsole \
 {% if provision_virt_install_extra_settings is defined %}
-  {% for param in provision_virt_install_extra_settings %}
-  {{ param }} \
-  {% endfor %}
+{% for param in provision_virt_install_extra_settings %}
+{{ param }} \
+{% endfor %}
 {% endif %}
 {% if guest_type is not defined or guest_type != "image" %}
 {% if ansible_distribution == "CentOS" and ansible_distribution_major_version|int >= 7 %}

--- a/templates/virt-install-script.sh.j2
+++ b/templates/virt-install-script.sh.j2
@@ -11,8 +11,13 @@ virt-install \
   --connect=qemu:///system \
   --autostart \
   --noautoconsole \
+{% if provision_virt_install_extra_settings is defined %}
+  {% for param in provision_virt_install_extra_settings %}
+  {{ param }} \
+  {% endfor %}
+{% endif %}
 {% if guest_type is not defined or guest_type != "image" %}
-{% if ansible_distribution == "CentOS" and ansible_distribution_major_version == "7" %}
+{% if ansible_distribution == "CentOS" and ansible_distribution_major_version|int >= 7 %}
   --cpu=host-model \
 {% else %}
   --cpu=host \

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -120,8 +120,10 @@ function test_playbook(){
 }
 function extra_tests(){
 
+    echo "TEST: list all generate kickstart configs"
+    find /tmp/ -name *.ks -exec ls {} \;
     echo "TEST: print all generate kickstart configs"
-    cat /tmp/provision_vm.*/localhost.ks
+    find /tmp/ -name *.ks -exec cat {} \;
 
 }
 

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -120,10 +120,14 @@ function test_playbook(){
 }
 function extra_tests(){
 
-    echo "TEST: list all generate kickstart configs"
+    echo "TEST: list all generated kickstart configs"
     find /tmp/ -name *.ks -exec ls {} \;
-    echo "TEST: print all generate kickstart configs"
-    find /tmp/ -name *.ks -exec cat {} \;
+    echo "TEST: print all generated kickstart configs"
+    find /tmp/ -name *.sh.j2 -exec cat {} \;
+    echo "TEST: list all generated virt-install scripts"
+    find /tmp/ -name *.ks -exec ls {} \;
+    echo "TEST: print all generated virt-install scripts"
+    find /tmp/ -name *.sh.j2 -exec cat {} \;
 
 }
 

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -120,8 +120,8 @@ function test_playbook(){
 }
 function extra_tests(){
 
-    echo "TEST: ls /etc/puppet/*"
-    ls /etc/puppet/
+    echo "TEST: print all generate kickstart configs"
+    cat /tmp/provision_vm.*/localhost.ks
 
 }
 
@@ -137,7 +137,7 @@ function main(){
     test_playbook_syntax
     test_playbook
     test_playbook_check
-#    extra_tests
+    extra_tests
 
 }
 

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -123,9 +123,9 @@ function extra_tests(){
     echo "TEST: list all generated kickstart configs"
     find /tmp/ -name *.ks -exec ls {} \;
     echo "TEST: print all generated kickstart configs"
-    find /tmp/ -name *.sh.j2 -exec cat {} \;
+    find /tmp/ -name *.ks -exec cat {} \;
     echo "TEST: list all generated virt-install scripts"
-    find /tmp/ -name *.ks -exec ls {} \;
+    find /tmp/ -name *.sh.j2 -exec ls {} \;
     echo "TEST: print all generated virt-install scripts"
     find /tmp/ -name *.sh.j2 -exec cat {} \;
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -43,6 +43,8 @@
        - fqdn: "localhost"
        - install_url: "http://www.nic.funet.fi/pub/Linux/INSTALL/Centos/7/os/x86_64/"
        - root_password: "{{ lookup('password', 'credentials/'+ inventory_hostname  +'_rootpw length=15 chars=ascii_letters,digits,hexdigits,.,_,,') }}"
+       - root_password: "changemeorperish"
+       - provision_cleanup_runtimedir: False
 
    roles:
        - ansible-role-provision-vm

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -47,6 +47,8 @@
        - provision_cleanup_runtimedir: False
        - provision_virt_install_extra_settings:
          - "--numatune 1"
+         - "--graphics vnc,password={{ root_password }}"
+         - "--serial udp,host=10.0.0.1:514"
 
 
    roles:

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -45,6 +45,9 @@
        - root_password: "{{ lookup('password', 'credentials/'+ inventory_hostname  +'_rootpw length=15 chars=ascii_letters,digits,hexdigits,.,_,,') }}"
        - root_password: "changemeorperish"
        - provision_cleanup_runtimedir: False
+       - provision_virt_install_extra_settings:
+         - "--numatune 1"
+
 
    roles:
        - ansible-role-provision-vm


### PR DESCRIPTION
- Remove unused virt_install_cpu_model - it was deprecated in 3a54a8ebb6c944bbcd99e8683f7afac8ac2ef002
- New variable to define if one should remove the runtimedir or not, this is mostly for testing so one can print the resulting kickstart and virt-install scripts. To confirm that they look like after one makes changes to them.
- Make the jinja2 template about --cpu also apply to RHEL derivatives later than >= EL7