### PR TITLE
Remove FQDN in favour of inventory_hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ bridges:                   # One or more linux bridges on the hypevisor to conne
 
 Optional:
 ```
-fqdn: "{{ inventory_hostname }}"    # Defaults to the inventroy_hostname
-
 guest_type: image          # Defaults to "kickstart"
 
 # Bigger guests
@@ -31,7 +29,7 @@ guest_type: image          # Defaults to "kickstart"
 
 # Extra disks
 #disks:
-#  - path: "{{ libvirt_root }}/{{ fqdn }}.raw"
+#  - path: "{{ libvirt_root }}/{{ inventory_hostname }}.raw"
 #    size: 40
 
 # Networking setup

--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ hyper: hypervisor_hostname # Host where guest will be deployed.
 internal_ip: 1.2.3.4       # Primary IP address of the guest
 bridges:                   # One or more linux bridges on the hypevisor to connect VMs to
   - br-example
-fqdn: hypervisor_hostname.fully.qualified.example
 ```
 
 Optional:
 ```
+fqdn: "{{ inventory_hostname }}"    # Defaults to the inventroy_hostname
+
 guest_type: image          # Defaults to "kickstart"
 
 # Bigger guests

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 # Common settings ###############################
 #################################################
 
+fqdn: "{{ inventory_hostname }}"
 # Time to wait for install to finish (in minutes)
 install_timeout: "30"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,6 @@
 # Common settings ###############################
 #################################################
 
-fqdn: "{{ inventory_hostname }}"
 # Time to wait for install to finish (in minutes)
 install_timeout: "30"
 
@@ -49,7 +48,7 @@ set_ansible_host_to_internal_ip: Yes
 
 # Disks
 disks:
-  - path: "{{ image_path }}/{{ fqdn }}.raw"
+  - path: "{{ image_path }}/{{ inventory_hostname }}.raw"
     size: "{{ root_disk_size }}"
 
 # What packages to exclude in yum.conf at install time

--- a/tasks/image-guest.yml
+++ b/tasks/image-guest.yml
@@ -51,7 +51,7 @@
     copy:
       remote_src: true
       src: "{{ runtime_tempdir }}/cloud-init.iso"
-      dest: "{{ image_path}}/{{ fqdn }}.iso"
+      dest: "{{ image_path}}/{{ inventory_hostname }}.iso"
       mode: 0400
       owner: qemu
       group: qemu
@@ -61,7 +61,7 @@
     copy:
       remote_src: true
       src: "{{ image_path}}/{{ image_name }}"
-      dest: "{{ image_path}}/{{ fqdn }}.qcow2"
+      dest: "{{ image_path}}/{{ inventory_hostname }}.qcow2"
       mode: 0600
       owner: qemu
       group: qemu
@@ -80,7 +80,7 @@
       - "'7' in image_name"
 
   - name: Fix CentOS 7 image to networking
-    command: "/usr/bin/guestfish --rw -a {{ image_path}}/{{ fqdn }}.qcow2 -f {{ runtime_tempdir }}/modify-centos-image.guestfish"
+    command: "/usr/bin/guestfish --rw -a {{ image_path}}/{{ inventory_hostname }}.qcow2 -f {{ runtime_tempdir }}/modify-centos-image.guestfish"
     environment:
       LIBGUESTFS_BACKEND: direct # Fix first run on clean host with no VMs
     become: yes
@@ -89,7 +89,7 @@
       - "'7' in image_name"
 
   - name: Resize image to use whole disk
-    command: qemu-img resize {{ image_path}}/{{ fqdn }}.qcow2 {{ root_disk_size }}G
+    command: "qemu-img resize {{ image_path}}/{{ inventory_hostname }}.qcow2 {{ root_disk_size }}G"
     become: yes
 
   # This fact is picked up by the virt-install-command.j2 template and
@@ -97,7 +97,7 @@
   - name: Set the disk fact
     set_fact:
       disks:
-        - path: "{{ image_path}}/{{ fqdn }}.qcow2"
+        - path: "{{ image_path}}/{{ inventory_hostname }}.qcow2"
           size: "{{ root_disk_size }}"
           format: qcow2
 

--- a/templates/kickstart.cfg
+++ b/templates/kickstart.cfg
@@ -97,7 +97,7 @@ hiera
 echo "exclude={{ yum_exclude }}" >> /etc/yum.conf
 /usr/bin/yum clean all
 /usr/bin/yum update -y --skip-broken
-echo "{{ internal_ip }} {{ fqdn }}" >> /etc/hosts
+echo "{{ internal_ip }} {{ inventory_hostname }}" >> /etc/hosts
 {% if puppetmaster_ip is defined %}
 echo "{{ puppetmaster_ip }}  puppetmaster puppet {{ puppetmaster_fqdn }}" >> /etc/hosts
 {% endif %}

--- a/templates/virt-install-script.sh.j2
+++ b/templates/virt-install-script.sh.j2
@@ -30,6 +30,6 @@ virt-install \
   --extra-args="ks=file:/{{ inventory_hostname }}.ks"
 {% else %}
   --events on_poweroff=preserve \
-  --disk path={{ image_path}}/{{ fqdn }}.iso,device=cdrom,perms=ro \
+  --disk path={{ image_path}}/{{ inventory_hostname }}.iso,device=cdrom,perms=ro \
   --os-type=linux
 {% endif %}

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -40,7 +40,6 @@
              address: "{{ internal_ip }}"
              netmask: 255.255.255.0
        - bridges: [ "br-example" ]
-       - fqdn: "localhost"
        - install_url: "http://www.nic.funet.fi/pub/Linux/INSTALL/Centos/7/os/x86_64/"
        - root_password: "{{ lookup('password', 'credentials/'+ inventory_hostname  +'_rootpw length=15 chars=ascii_letters,digits,hexdigits,.,_,,') }}"
        - root_password: "changemeorperish"


### PR DESCRIPTION
fqdn might be confused with ansible_fqdn which requires gather_facts which might be different on different nodes. By using ansible_inventory we can be sure that the fact is always correct.

This should be reviewed as part of similar PRs.
CCCP-2888