### PR TITLE
Use package module to install libguestfs-tools

### DIFF
--- a/tasks/image-guest.yml
+++ b/tasks/image-guest.yml
@@ -5,7 +5,7 @@
 - block:
 
   - name: Ensure guestfish is installed
-    yum:
+    package:
       name: libguestfs-tools
       state: installed
     become: yes

--- a/tasks/image-guest.yml
+++ b/tasks/image-guest.yml
@@ -7,7 +7,7 @@
   - name: Ensure guestfish is installed
     package:
       name: libguestfs-tools
-      state: installed
+      state: present
     become: yes
 
   # Fetch a ready made OpenStack image.


### PR DESCRIPTION
It's called the same in Debian!

On debian 10:
```
$ apt show libguestfs-tools
Package: libguestfs-tools
Version: 1:1.40.2-2
```