### PR TITLE
Default to selinux=enabled for centos8 (stream)

### DIFF
--- a/templates/kickstart.cfg
+++ b/templates/kickstart.cfg
@@ -66,7 +66,12 @@ selinux --permissive
 {% endif %}
 
 # disks
+{% if disable_selinux is defined %}
 bootloader --location=mbr --append="selinux=0"
+{% else %}
+bootloader --location=mbr"
+{%endif %}
+
 {% endif %}
 zerombr
 clearpart --all --initlabel


### PR DESCRIPTION
Add selinux=0 bootparameter for Centos8 to disable selinux, only if disable_selinux is set for host(group).