### PR TITLE
Enable kickstarting puppetmaster5-devel.epouta in Alma8

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,10 @@ guest_type: image          # Defaults to "kickstart"
 #            - pci_0000_3b_00_4
 #   In this example the specific devices pci_0000_3b_00_3 will be passed through to the virtual machine.
 
-# if you still in 2022 and beyond want to disable selinux, set
-# disable_selinux: True
-# or if you want to set selinux to permissive set this instead 
-# permissive_selinux: True 
-# by default selinux should be on ( os hardening 101 )
+# kickstart_selinux is an optional parameter that regulates kickstart instructions related with selinux
+# by default, kickstart_selinux is not defined and no selinux instructions will be added to the kickstart file, resulting in selinux being set to "enforcing" in the kickstarted operating system
+# kickstart_selinux can also be explicitly set to "enforcing", producing the same effect as above
+# kickstart_selinux can be set to "permissive" or "disabled", resulting in selinux being set respectively to "permissive" or "disabled" in the kickstarted operating system
 
 #environment: default-environment
 

--- a/templates/kickstart.cfg
+++ b/templates/kickstart.cfg
@@ -64,7 +64,7 @@ selinux --permissive
 {% if disable_selinux is defined %}
 bootloader --location=mbr --append="selinux=0"
 {% else %}
-bootloader --location=mbr"
+bootloader --location=mbr
 {%endif %}
 zerombr
 clearpart --all --initlabel

--- a/templates/kickstart.cfg
+++ b/templates/kickstart.cfg
@@ -52,11 +52,6 @@ authselect --useshadow --passalgo=sha512 --kickstart
 authconfig --useshadow --passalgo=sha512 --kickstart
 {% endif %}
 
-{% if os_variant in ["centos8", "centos-stream8", "centos-stream9", "almalinux8", "almalinux9"] %}
-# disks
-bootloader --location=mbr
-{% else %}
-
 {% if disable_selinux is defined %}
 selinux --disabled
 {% endif %}
@@ -71,8 +66,6 @@ bootloader --location=mbr --append="selinux=0"
 {% else %}
 bootloader --location=mbr"
 {%endif %}
-
-{% endif %}
 zerombr
 clearpart --all --initlabel
 {% if kickstart_partitions is defined %}

--- a/templates/kickstart.cfg
+++ b/templates/kickstart.cfg
@@ -46,7 +46,7 @@ logging --host={{ central_log_host|replace("@","") }}
 # authentication
 rootpw {{ root_password }}
 
-{% if os_variant in ["centos8", "centos-stream8", "centos-stream9", "almalinux8", "almalinux9"] %}
+{% if os_variant not in ["rhel6", "rhel7"] %}
 authselect --useshadow --passalgo=sha512 --kickstart
 {% else %}
 authconfig --useshadow --passalgo=sha512 --kickstart

--- a/templates/kickstart.cfg
+++ b/templates/kickstart.cfg
@@ -52,16 +52,20 @@ authselect --useshadow --passalgo=sha512 --kickstart
 authconfig --useshadow --passalgo=sha512 --kickstart
 {% endif %}
 
-{% if disable_selinux is defined %}
+{% if kickstart_selinux is defined and kickstart_selinux == 'disabled' %}
 selinux --disabled
 {% endif %}
 
-{% if permissive_selinux is defined %}
+{% if kickstart_selinux is defined and kickstart_selinux == 'permissive' %}
 selinux --permissive
 {% endif %}
 
+{% if kickstart_selinux is defined and kickstart_selinux == 'enforcing' %}
+selinux --enforcing
+{% endif %}
+
 # disks
-{% if disable_selinux is defined %}
+{% if kickstart_selinux is defined and kickstart_selinux == 'disabled' %}
 bootloader --location=mbr --append="selinux=0"
 {% else %}
 bootloader --location=mbr

--- a/templates/kickstart.cfg
+++ b/templates/kickstart.cfg
@@ -46,13 +46,13 @@ logging --host={{ central_log_host|replace("@","") }}
 # authentication
 rootpw {{ root_password }}
 
-{% if os_variant == "centos8" %}
+{% if os_variant in ["centos8", "centos-stream8", "centos-stream9", "almalinux8", "almalinux9"] %}
 authselect --useshadow --passalgo=sha512 --kickstart
 {% else %}
 authconfig --useshadow --passalgo=sha512 --kickstart
 {% endif %}
 
-{% if os_variant == "centos8" %}
+{% if os_variant in ["centos8", "centos-stream8", "centos-stream9", "almalinux8", "almalinux9"] %}
 # disks
 bootloader --location=mbr
 {% else %}
@@ -92,7 +92,7 @@ services --enabled fstrim.timer
 kexec-tools
 
 {% else %}
-%packages --nobase
+%packages
 @core
 {% endif %}
 {% if repos is defined %}

--- a/templates/virt-install-script.sh.j2
+++ b/templates/virt-install-script.sh.j2
@@ -36,7 +36,7 @@ virt-install \
  --wait={{ install_timeout }} \
   --location={{ install_url }} \
   --initrd-inject={{ runtime_tempdir }}/{{ inventory_hostname }}.ks \
-{% if os_variant == "centos8" %}
+{% if os_variant in ["centos8", "centos-stream8", "centos-stream9", "almalinux8", "almalinux9"] %}
     --extra-args="inst.text inst.ks=file:/{{ inventory_hostname }}.ks"
 {% else %}
     --extra-args="ks=file:/{{ inventory_hostname }}.ks"

--- a/templates/virt-install-script.sh.j2
+++ b/templates/virt-install-script.sh.j2
@@ -36,7 +36,7 @@ virt-install \
  --wait={{ install_timeout }} \
   --location={{ install_url }} \
   --initrd-inject={{ runtime_tempdir }}/{{ inventory_hostname }}.ks \
-{% if os_variant in ["centos8", "centos-stream8", "centos-stream9", "almalinux8", "almalinux9"] %}
+{% if os_variant not in ["rhel6", "rhel7"] %}
     --extra-args="inst.text inst.ks=file:/{{ inventory_hostname }}.ks"
 {% else %}
     --extra-args="ks=file:/{{ inventory_hostname }}.ks"


### PR DESCRIPTION
The PR mostly contains the changes required by puppetmaster5-devel.epouta but it also contains some tools/structure that can be used with Alma9 VMs too
disable_selinux and permissive_selinux have been refactored into a single kickstart_selinux parameter, which has been designed to not require further changes to the current codebase (previous/default behavior is unchanged)