### PR TITLE
Remove authselect useless command

### DIFF
--- a/templates/kickstart.cfg
+++ b/templates/kickstart.cfg
@@ -46,9 +46,7 @@ logging --host={{ central_log_host|replace("@","") }}
 # authentication
 rootpw {{ root_password }}
 
-{% if os_variant not in ["rhel6", "rhel7"] %}
-authselect --useshadow --passalgo=sha512 --kickstart
-{% else %}
+{% if os_variant in ["rhel6", "rhel7"] %}
 authconfig --useshadow --passalgo=sha512 --kickstart
 {% endif %}
 


### PR DESCRIPTION
Auth and authconfig are deprecated in RHEL8 and removed completely in RHEL9. Authselect is used instead, but it does not actually accept the same args as auth and authconfig commands.

From authselect-migration manual page:
Note
Authconfig options --enableshadow and --passalgo=sha512 were often used to make sure that passwords are stored in /etc/shadow using sha512 algorithm. The authselect profiles now use the sha512 hashing method and it cannot be changed through an option (only by creating a custom profile). You can just omit these options.

This commit thus removes the authselect statement.

Note that here the implicit assumption is that os_variant indicates not only the OS which the VM will run, but also the operating system from which the VM is kickstarted, given that the kickstart commands are meant for the latter.