### PR TITLE
make sure pubkeys are fetched correctly

### DIFF
--- a/templates/user-data.j2
+++ b/templates/user-data.j2
@@ -19,7 +19,7 @@ users:
   - name: {{ adminuser.name }}
     sudo: ALL=(ALL) NOPASSWD:ALL
     ssh-authorized-keys:
-{% for sshkey in adminuser.pubkeys %}
-      - {{ sshkey.pubkey }}
-{% endfor %}
+{% if adminuser.pubkey is defined %}
+      - {{ adminuser.pubkey }}
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
I guess we are using adminuser.pubkey instead of adminuser.pubkeys. The old implementation enables looping over and adding multiple keys for same admin user, but to use old way we would need change our variable listing our adminuser pubkeys.
