### PR TITLE
updates to virt-install script

### DIFF
--- a/templates/virt-install-script.sh.j2
+++ b/templates/virt-install-script.sh.j2
@@ -10,11 +10,13 @@ virt-install \
   --virt-type kvm \
 {% endif %}
 {% for bridge in bridges %}
+{% set bridge_config = "model=virtio" %}
 {% if virtio_multiqueue is defined %}
-  --network bridge={{ bridge }},model=virtio,driver_name=vhost,driver_queues={{ vcpus }} \
-{% else %}
-  --network bridge={{ bridge }},model=virtio \
+{% set bridge_config = bridge_config + ",driver_name=vhost,driver_queues=%s" % vcpus %}
+{% elif mac_address is defined %}
+{% set bridge_config = bridge_config + ",mac=%s" % mac_address %}
 {% endif %}
+  --network bridge={{ bridge }},{{ bridge_config }} \
 {% endfor %}
 {% if guest_type is not defined or guest_type != "image" %}
 {% if provision_virt_install_extra_settings is defined %}

--- a/templates/virt-install-script.sh.j2
+++ b/templates/virt-install-script.sh.j2
@@ -18,17 +18,13 @@ virt-install \
 {% endif %}
   --network bridge={{ bridge }},{{ bridge_config }} \
 {% endfor %}
+{% set default_args = "console=tty0 inst.text plymouth.enable=0 " %}
 {% if guest_type is not defined or guest_type != "image" %}
-{% if provision_virt_install_extra_settings is defined %}
-{% for param in provision_virt_install_extra_settings %}
-  {{ param }} \
-{% endfor %}
+{% set default_args = default_args + "inst.ks=file:/%s.ks" % inventory_hostname %}
+{% set custom_args = provision_virt_install_extra_settings | join(' ') if provision_virt_install_extra_settings is defined else "" %}
+  --extra-args="{{ default_args }} {{ custom_args }}" \
 {% endif %}
-{% if ansible_distribution == "CentOS" and ansible_distribution_major_version|int >= 7 %}
   --cpu=host-model \
-{% else %}
-  --cpu=host \
-{% endif %}
 {% for device in (vm_pci_passthrough_devices | default([])) %}
   --host-device={{ device }} \
 {% endfor %}
@@ -36,12 +32,6 @@ virt-install \
   --wait={{ install_timeout }} \
   --location={{ install_url }} \
   --initrd-inject={{ runtime_tempdir }}/{{ inventory_hostname }}.ks \
-{% if os_variant not in ["rhel6", "rhel7"] %}
-  --extra-args="console=tty0 console=ttyS0,115200 inst.text inst.ks=file:/{{ inventory_hostname }}.ks" \
-{% else %}
-  --extra-args="ks=file:/{{ inventory_hostname }}.ks"
-{% endif %}
-{% endif %}
 {% if os_variant is defined %}
   --os-variant={{ os_variant }} \
   --os-type=linux \

--- a/templates/virt-install-script.sh.j2
+++ b/templates/virt-install-script.sh.j2
@@ -34,7 +34,6 @@ virt-install \
   --initrd-inject={{ runtime_tempdir }}/{{ inventory_hostname }}.ks \
 {% if os_variant is defined %}
   --os-variant={{ os_variant }} \
-  --os-type=linux \
 {% endif %}
 {% for disk in disks %}
   --disk path={{ disk.path }},cache=writethrough,discard=unmap,device=disk,bus=virtio,size={{ disk.size }},format={{ disk.format | default('raw') }}

--- a/templates/virt-install-script.sh.j2
+++ b/templates/virt-install-script.sh.j2
@@ -28,7 +28,7 @@ virt-install \
 {% for device in (vm_pci_passthrough_devices | default([])) %}
   --host-device={{ device }} \
 {% endfor %}
-  --graphics=vnc,keymap="fi" \
+  {{ kickstart_graphics | default('--nographics') }} \
   --wait={{ install_timeout }} \
   --location={{ install_url }} \
   --initrd-inject={{ runtime_tempdir }}/{{ inventory_hostname }}.ks \


### PR DESCRIPTION
Changes to the virt-install script:

* [Enable defining both virtio_multioqueue and mac_address for bridge configurations.](https://github.com/CSCfi/ansible-role-provision-vm/pull/53/commits/0e111293fc9f6eaef85ce36a01579b7841cd598e)
* [Combine --extra-args into one parameter to ensure all settings are effective.](https://github.com/CSCfi/ansible-role-provision-vm/pull/53/commits/292aea74866dd2dca38abd3b1872ec9a71b98e0b)
* [Remove --os-type=linux as deprecated code.](https://github.com/CSCfi/ansible-role-provision-vm/pull/53/commits/4ba872a34754ed5265ba71060c6f0c9f1ec2d4cc)
* [enable choosing your own kickstart_graphics configuration.](https://github.com/CSCfi/ansible-role-provision-vm/pull/53/commits/5fb40f443fe5c1a47f31f661da583ec2bf3fc2e1)